### PR TITLE
Manually remove bitballoon.com and netlify.com from TLD list

### DIFF
--- a/data/public_suffix_list.dat
+++ b/data/public_suffix_list.dat
@@ -11879,11 +11879,6 @@ net.ru
 org.ru
 pp.ru
 
-// Netlify : https://www.netlify.com
-// Submitted by Jessica Parsons <jessica@netlify.com>
-bitballoon.com
-netlify.com
-
 // Neustar Inc.
 // Submitted by Trung Tran <Trung.Tran@neustar.biz>
 4u.com

--- a/lib/domain_name/etld_data.rb
+++ b/lib/domain_name/etld_data.rb
@@ -8155,8 +8155,6 @@ class DomainName
     "net.ru" => 0,
     "org.ru" => 0,
     "pp.ru" => 0,
-    "bitballoon.com" => 0,
-    "netlify.com" => 0,
     "4u.com" => 0,
     "ngrok.io" => 0,
     "nh-serv.co.uk" => 0,


### PR DESCRIPTION
Lots of place (especially looking up the TLS certificate) will break if `bitballoon.com` or `netlify.com` is being TLD. This causes something like the following:

* example: `dn = DomainName('foo.bitballoon.com')`
  * before(works): `dn.domain => bitballoon.com`, after: `dn.domain => foo.bitballoon.com`
* example: `dn = DomainName('bitballoon.com')`
  * before(works): `dn.domain => bitballoon.com`, after: `dn.domain => nil`

By removing these from eTLD data, the behavior will be "before(works)" version with updated TLD.