### PR TITLE
Add `ignore` argument to initializer

### DIFF
--- a/lib/domain_name.rb
+++ b/lib/domain_name.rb
@@ -75,7 +75,8 @@ class DomainName
 
   # Parses _hostname_ into a DomainName object.  An IP address is also
   # accepted.  An IPv6 address may be enclosed in square brackets.
-  def initialize(hostname)
+  # _ignore_ is a list of domains to ignore from the eltd data.
+  def initialize(hostname, ignore: [])
     hostname.is_a?(String) or
       (hostname.respond_to?(:to_str) && (hostname = hostname.to_str).is_a?(String)) or
       raise TypeError, "#{hostname.class} is not a String"
@@ -104,7 +105,7 @@ class DomainName
     else
       @tld = @hostname
     end
-    etld_data = DomainName.etld_data
+    etld_data = DomainName.etld_data.reject { |k, _| ignore.include?(k) }
     if @canonical_tld_p = etld_data.key?(@tld)
       subdomain = domain = nil
       parent = @hostname
@@ -292,6 +293,6 @@ class DomainName
 end
 
 # Short hand for DomainName.new().
-def DomainName(hostname)
-  DomainName.new(hostname)
+def DomainName(hostname, ignore: [])
+  DomainName.new(hostname, ignore: ignore)
 end

--- a/test/test_domain_name.rb
+++ b/test/test_domain_name.rb
@@ -314,4 +314,12 @@ class TestDomainName < Test::Unit::TestCase
     assert_equal "xn--wgv71a", dn.tld
     assert_equal "日本", dn.tld_idn
   end
+
+  test "accepts an ignore argument" do
+    dn = DomainName.new("foo.netlify.com", ignore: ["netlify.com"])
+    assert_equal "netlify.com", dn.domain
+
+    dn = DomainName("netlify.com", ignore: ["netlify.com"])
+    assert_equal "netlify.com", dn.domain
+  end
 end


### PR DESCRIPTION
This provides a way to dynamically ignore some domains for the etld_data
provided. This can be helpful for some places like looking up the TLS
certificate, where we need netlify.com or bitballoon.com to be returned
as the domain.

Closes #1.